### PR TITLE
voicemail-admin additions to data access layer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
         options: {
           mocha: require('mocha'),
           reporter: 'spec',
-          timeout: 2000
+          timeout: 6000
         },
         src: ['test/*.js']
       }

--- a/lib/repositories/context.js
+++ b/lib/repositories/context.js
@@ -60,6 +60,32 @@ function createApi(table, provider, sqlGenerator, dependencies) {
     },
 
     /**
+     * Returns an array of all context instances from the database.
+     */
+    all: function() {
+      dependencies.logger.trace('context.all called');
+
+      var query = table
+        .select(table.star())
+        .from(table)
+        .toQuery();
+
+      return common.find(query, provider, constructor.bind(this))
+        .then(function(result) {
+          return result.reduce(function(contexts, context) {
+            contexts.push(context);
+            return contexts;
+          }, []);
+        });
+
+      function constructor(id) {
+        /*jshint validthis:true*/
+        // Passing undefined so that domain can be populated by db result
+        return this.create(undefined, id);
+      }
+    },
+
+    /**
      * Return a context instance from the database.
      */
     get: function(domain) {

--- a/lib/repositories/folder.js
+++ b/lib/repositories/folder.js
@@ -82,14 +82,64 @@ function createApi(table, provider, sqlGenerator, dependencies) {
 
       return common.find(query, provider, constructor.bind(this))
         .then(function(result) {
-          dependencies.logger.debug({
-            folders: result
-          }, 'Folders loaded');
-
           return result.reduce(function(folders, folder) {
             folders.add(folder);
             return folders;
           }, collection());
+        });
+
+      function constructor(id) {
+        /*jshint validthis:true*/
+        return this.create(id);
+      }
+    },
+
+    /**
+     * Return a folder instance from the database.
+     */
+    get: function(name) {
+      dependencies.logger.trace('folder.get called');
+
+      var where = table.name
+            .equals(name);
+
+      return common.get(table, where, provider, constructor.bind(this))
+        .then(function(folder) {
+          dependencies.logger.debug({folder: folder}, 'Folder loaded');
+
+          return folder;
+        });
+
+      function constructor(id) {
+        /*jshint validthis:true*/
+        return this.create(id);
+      }
+    },
+
+    /**
+     * Return an array of folders instance from the database matching
+     * the name or DTMF provided. Useful for checking for conflicts
+     * prior to adding a new item.
+     */
+    findByNameOrDTMF: function(name, dtmf) {
+      dependencies.logger.trace('folder.findByNameOrDtmf called');
+
+      var where = table.name.equals(name)
+                  .or(table.dtmf.equals(dtmf));
+
+      var query = table
+        .select(table.star())
+        .from(table)
+        .where(where)
+        .toQuery();
+
+      return common.find(query, provider, constructor.bind(this))
+        .then(function(result) {
+          dependencies.logger.debug({
+            folders: result
+          }, 'Folders loaded');
+
+          return result;
         });
 
       function constructor(id) {
@@ -144,6 +194,7 @@ function createApi(table, provider, sqlGenerator, dependencies) {
 
     return collectionObj;
   }
+
 }
 
 /**

--- a/lib/repositories/mailbox.js
+++ b/lib/repositories/mailbox.js
@@ -82,6 +82,49 @@ function createApi(table, provider, sqlGenerator, dependencies) {
     },
 
     /**
+     * Returns an array of all mailboxes belonging to the specified context
+     */
+    findByContext: function(context) {
+      dependencies.logger.trace('mailbox.findByContext called');
+
+      var query = table
+        .select(table.star())
+        .from(table)
+        .where(table['context_id'].equals(context.getId()))
+        .toQuery();
+
+      return common.find(query, provider, constructor.bind(this))
+        .then(function(result) {
+          return result.reduce(function(mailboxes, mailbox) {
+            mailboxes.push(mailbox);
+            return mailboxes;
+          }, []);
+        });
+
+      function constructor(id) {
+        /*jshint validthis:true*/
+        //Passing undefined so that number can be populated by db result
+        return this.create(undefined, context, id);
+      }
+
+    },
+
+    /**
+     * Returns count of all mailboxes belonging to the specified context
+     */
+    countByContext: function(context) {
+      dependencies.logger.trace('mailbox.countByContext called');
+
+      var query = table
+        .select('count(*)')
+        .from(table)
+        .where(table['context_id'].equals(context.getId()))
+        .toQuery();
+
+      return common.count(table, query, provider);
+    },
+
+    /**
      * Return a mailbox instance from the database.
      */
     get: function(number, context) {

--- a/lib/repositories/message.js
+++ b/lib/repositories/message.js
@@ -132,6 +132,37 @@ function createApi(table, provider, sqlGenerator, dependencies) {
       }
     },
 
+    /**
+     * Returns a count of all messages for the given mailbox.
+     */
+    countByMailbox: function(mailbox) {
+      dependencies.logger.trace('message.countByMailbox called');
+
+      var query = table
+        .select('count(*)')
+        .from(table)
+        .where(table['mailbox_id'].equals(mailbox.getId()))
+        .toQuery();
+
+      return common.count(table, query, provider);
+
+    },
+
+    /**
+     * Returns a count of all messages for the given folder.
+     */
+    countByFolder: function(folder) {
+      dependencies.logger.trace('message.countByFolder called');
+
+      var query = table
+        .select('count(*)')
+        .from(table)
+        .where(table['folder_id'].equals(folder.getId()))
+        .toQuery();
+
+      return common.count(table, query, provider);
+    },
+
     /*
      * Returns a Messages object containing all messages for the given mailbox
      * and folder.
@@ -352,7 +383,7 @@ function createApi(table, provider, sqlGenerator, dependencies) {
     /**
      * Deletes a message instance from the database.
      */
-    remove: function remove(instance) {
+    remove: function (instance) {
       dependencies.logger.trace('message.remove called');
 
       var query = table
@@ -394,6 +425,46 @@ function createApi(table, provider, sqlGenerator, dependencies) {
                 });
             });
         });
+    },
+
+    /**
+     * Deletes all messages belonging to the specific mailbox
+     */
+    removeByMailbox: function (mailbox) {
+      dependencies.logger.trace('message.removeByMailbox called');
+
+      var query = table
+        .select(table.star())
+        .from(table)
+        .where(table['mailbox_id'].equals(mailbox.getId()))
+        .toQuery();
+      query = provider.forUpdate(query);
+
+      return provider.beginTransaction(true)
+        .then(function(transaction) {
+
+          return transaction.runQuery(query)
+            .then(function(result) {
+              var query = table
+                .delete()
+                .where(table['mailbox_id'].equals(mailbox.getId()))
+                .toQuery();
+
+              return transaction.runQuery(query)
+                .then(function() {
+                  return transaction.commit();
+                })
+                .then(function() {
+                  dependencies.logger.debug('Messages removed');
+                });
+            })
+            .catch(function(err) {
+              return transaction.rollback()
+                .finally(function() {
+                  throw new Error(err);
+                });
+            });
+        });
     }
   };
 
@@ -403,7 +474,7 @@ function createApi(table, provider, sqlGenerator, dependencies) {
   function count(mailbox, folder) {
     dependencies.logger.trace('message.count called');
 
-     var query = table
+    var query = table
       .select('count(*)')
       .from(table)
       .where(table['mailbox_id'].equals(mailbox.getId())

--- a/test/folder.js
+++ b/test/folder.js
@@ -111,6 +111,51 @@ describe('folder', function () {
       .done();
   });
 
+  it('should support getting a folder by name', function(done) {
+    helper.dal.folder.get('Old')
+      .then(function(result) {
+        assert(result.name === 'Old');
+        assert(result.recording === 'Old');
+        assert(result.dtmf === 1);
+        done();
+      });
+  });
+
+  function resultEquivalentExpectations(result, expectedItems) {
+    if (result.length !== expectedItems.length) {
+      return false;
+    }
+
+    result.forEach(function (item) {
+      expectedItems = expectedItems.filter(function (expectedItem) {
+        if (expectedItem.name === item.name &&
+            expectedItem.recording === item.recording &&
+            expectedItem.dtmf === item.dtmf) {
+          return false;
+        }
+
+        return true;
+      });
+    });
+
+    if (expectedItems.length === 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  it('should support finding folders by name/dtmf', function(done) {
+    var expectedItems = [{'name': 'Inbox', 'recording': 'INBOX', 'dtmf': 0},
+                         {'name': 'Old', 'recording': 'Old', 'dtmf': 1}];
+
+    helper.dal.folder.findByNameOrDTMF('Inbox', 1)
+      .then(function(result) {
+        assert(resultEquivalentExpectations(result, expectedItems));
+        done();
+      });
+  });
+
   it('should support creating indexes', function(done) {
     helper.dal.folder.createIndexes()
       .then(function() {

--- a/test/mailbox.js
+++ b/test/mailbox.js
@@ -22,7 +22,7 @@ describe('mailbox', function () {
     connectionString: 'tests.db',
     provider: 'sqlite'
   };
-  var asyncDelay = 50;
+  var asyncDelay = 200;
   var helper;
   var mwi = function() {
     /*jshint newcap:false*/
@@ -125,6 +125,50 @@ describe('mailbox', function () {
       })
       .then(function(result) {
         assert(result === null);
+        done();
+      })
+      .done();
+  });
+
+  function verifyMailboxesMatchResults(result, expectedItems) {
+    if (result.length !== expectedItems.length) {
+      return false;
+    }
+
+    result.forEach(function (item) {
+      var index = expectedItems.indexOf(item.mailboxNumber);
+      if (index <= -1) {
+        return;
+      }
+
+      expectedItems.splice(index, 1);
+    });
+
+    if (expectedItems.length === 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  it('should support finding mailboxes by context', function(done) {
+    var context = helper.context;
+    var expectedMailboxNumbers = [1234, 1111];
+
+    helper.dal.mailbox.findByContext(context)
+      .then(function(result) {
+        assert(verifyMailboxesMatchResults(result, expectedMailboxNumbers));
+        done();
+      })
+      .done();
+  });
+
+  it('should support counting mailboxes by context', function(done) {
+    var context = helper.context;
+
+    helper.dal.mailbox.countByContext(context)
+      .then(function(result) {
+        assert(result === 2);
         done();
       })
       .done();

--- a/test/message.js
+++ b/test/message.js
@@ -22,7 +22,7 @@ describe('message', function () {
     provider: 'sqlite'
   };
   var helper;
-  var asyncDelay = 100;
+  var asyncDelay = 300;
 
   beforeEach(function (done) {
     common.populateDb(config)
@@ -391,5 +391,19 @@ describe('message', function () {
         assert(alreadyExists);
         done();
       });
+  });
+
+  it('should support removing all messages for a mailbox', function(done) {
+    var mailbox = helper.mailbox;
+
+    helper.dal.message.removeByMailbox(mailbox)
+      .then(function() {
+        return helper.dal.message.countByMailbox(mailbox);
+      })
+      .then(function(count) {
+        assert(count === 0);
+        done();
+      })
+      .done();
   });
 });


### PR DESCRIPTION
Adds following functions and tests for them.

context: all() - retrieves all contexts
folder: get(name) - retrieves a folder by name
folder: getNameOrDTMF(name, dtmf) - retrieves all folders matching either the name or the dtmf
mailbox: allContext(context) - retrieves all mailboxes matching the context
mailbox: countContext(context) - counts all mailboxes matching the context
message: removeMailbox(mailbox) - removes all messages belonging to a specific mailbox
